### PR TITLE
Add Numpy to the list of packages in CMAKE and fix 47: error: ‘_1’ was not declared in this scope.

### DIFF
--- a/Schweizer-Messer/python_module/cmake/add_python_export_library.cmake
+++ b/Schweizer-Messer/python_module/cmake/add_python_export_library.cmake
@@ -86,7 +86,7 @@ ${SETUP_PY_TEXT}
       list(APPEND BOOST_COMPONENTS python27)
     endif()
   else()
-    list(APPEND BOOST_COMPONENTS python38)
+    list(APPEND BOOST_COMPONENTS python)
   endif()
   find_package(Boost REQUIRED COMPONENTS ${BOOST_COMPONENTS}) 
 
@@ -145,6 +145,15 @@ ${SETUP_PY_TEXT}
   get_directory_property(AMCF ADDITIONAL_MAKE_CLEAN_FILES)
   list(APPEND AMCF ${PYTHON_LIB_DIR}/${PYLIB_OUTPUT_NAME})
   set_directory_properties(PROPERTIES ADDITIONAL_MAKE_CLEAN_FILES "${AMCF}") 
-  
+
+  # Add the python package to the list of packages to be installed
+  if(${CMAKE_VERSION} VERSION_GREATER "3.14") 
+    message("Add Numpy to the list of packages")
+  # cmake_minimum_required(VERSION 3.14)
+  find_package(Python3 COMPONENTS Interpreter Development NumPy REQUIRED)
+  target_include_directories(${TARGET_NAME} PRIVATE ${Python3_INCLUDE_DIRS})
+  target_include_directories(${TARGET_NAME} PRIVATE ${Python3_NumPy_INCLUDE_DIRS})
+  target_link_libraries(${TARGET_NAME} ${Python3_LIBRARIES})
+  endif()
 ENDFUNCTION()
 

--- a/aslam_nonparametric_estimation/bsplines_python/src/BSplinePython.cpp
+++ b/aslam_nonparametric_estimation/bsplines_python/src/BSplinePython.cpp
@@ -1,7 +1,8 @@
 #include <numpy_eigen/boost_python_headers.hpp>
 
 #include <bsplines/BSpline.hpp>
-
+using namespace std;
+using namespace placeholders;
 using namespace bsplines;
 using namespace boost::python;
 


### PR DESCRIPTION
Fix some bugs that may cause the CMAKE processing ERROR.